### PR TITLE
ブログ記事「ずっとLTしかやってこなかった私が・・・」を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,5 @@
 * [JJUG CCC 2016 Spring 聴講セッションのまとめ / 我らねぶた馬鹿](http://nebuta.hatenablog.jp/entry/2016/05/23/195514)
 * [じぇいじゃぐしーしーしー２０１６春に行ってきた。](http://kotomalism.hatenablog.com/entry/2016/05/24/024231)
 * [JJUG CCC 2016 Springに参加してきた。](http://d.hatena.ne.jp/megascus/20160524/1464050239)
+* [ずっとLTしかやってこなかった私がJJUG CCCでカンファレンス登壇デビューした件 #jjug_ccc #ccc_m62](http://sd-ts1017.hatenablog.com/entry/2016/05/22/234224)
 * Give me pull requests!


### PR DESCRIPTION
「ずっとLTしかやってこなかった私がJJUG CCCでカンファレンス登壇デビューした件 #jjug_ccc #ccc_m62」を追加お願いします。
http://sd-ts1017.hatenablog.com/entry/2016/05/22/234224
